### PR TITLE
Downgraded version of Lykke.SettingsReader.

### DIFF
--- a/src/Lykke.Job.Messages.Core/Lykke.Job.Messages.Core.csproj
+++ b/src/Lykke.Job.Messages.Core/Lykke.Job.Messages.Core.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Lykke.Service.ClientAccount.Client" Version="2.2.3" />
     <PackageReference Include="Lykke.Service.EmailSender" Version="1.1.0" />
     <PackageReference Include="Lykke.Service.PersonalData" Version="2.0.2" />
-    <PackageReference Include="Lykke.SettingsReader" Version="3.1.0" />
+    <PackageReference Include="Lykke.SettingsReader" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Lykke.Job.Messages.Contract\Lykke.Job.Messages.Contract\Lykke.Job.Messages.Contract.csproj" />

--- a/src/Lykke.Job.Messages/Lykke.Job.Messages.csproj
+++ b/src/Lykke.Job.Messages/Lykke.Job.Messages.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Lykke.Service.SwiftWithdrawal.Contracts" Version="1.0.2" />
     <PackageReference Include="Lykke.Service.TemplateFormatter.Client" Version="1.0.54" />
     <PackageReference Include="Lykke.Service.SmsSender.Client" Version="1.0.0" />
-    <PackageReference Include="Lykke.SettingsReader" Version="3.1.0" />
+    <PackageReference Include="Lykke.SettingsReader" Version="3.0.0" />
     <PackageReference Include="Lykke.SlackNotification.AzureQueue" Version="2.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />


### PR DESCRIPTION
Lykke.SettingsReader 3.1.0
Configuration.LoadSettings<AppSettings>()
>Value cannot be null.
>Parameter name: slackInfo
Works fine with version 3.0.0