### PR TITLE
Fixed bug: push sending for market orders.

### DIFF
--- a/src/Lykke.Job.Messages/Sagas/OrderExecutionSaga.cs
+++ b/src/Lykke.Job.Messages/Sagas/OrderExecutionSaga.cs
@@ -37,6 +37,9 @@ namespace Lykke.Job.Messages.Sagas
             var order = evt.Order;
             var walletId = order.WalletId;
 
+            if (order.Type != OrderType.Limit && order.Type != OrderType.StopLimit)
+                return;
+
             if (order.Trades == null || !order.Trades.Any())
             {
                 _log.Warning("The order has no trades.");


### PR DESCRIPTION
Push notification for trade executed events should be sent for limit orders only.
https://lykkex.atlassian.net/browse/LWDEV-8925